### PR TITLE
Fix NameError in grid_wrapper initialization

### DIFF
--- a/emcee/pyradex/grid_wrapper.py
+++ b/emcee/pyradex/grid_wrapper.py
@@ -32,8 +32,11 @@ def grid_wrapper(molecule,
              for tid in transition_indices}
 
     # Just a quick first run to get things initialized
-    if coltype == 'mol':
-        R = Radex(species=molecule, column=columns[0], abundance=abundances[0])
+    # ``coltype`` was never defined and therefore always raised a NameError.
+    # The initial run simply needs a Radex instance to set up the
+    # frequency grid, so instantiate it unconditionally using the first
+    # column and abundance values.
+    R = Radex(species=molecule, column=columns[0], abundance=abundances[0])
     R.deltav = deltav
     R.run_radex()
 


### PR DESCRIPTION
## Summary
- remove use of undefined `coltype`
- always instantiate `Radex` for initial frequency setup

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685d96b0cb848326aa4cb45cc63cd7f1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue that could cause errors during grid setup, improving reliability when initializing frequency grids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->