### PR TITLE
Adding a new plot for the cloested-to-median values which gives bette…

### DIFF
--- a/emcee/emcee_radex.py
+++ b/emcee/emcee_radex.py
@@ -252,32 +252,6 @@ def nearest_sample_to_vector(samples, target, metric='mahalanobis', eps=1e-9):
         # regularize for numerical stability
         C.flat[::C.shape[0] + 1] += eps
         L = np.linalg.cholesky(C)
-        delta = (X - t).T                               # shape (D, N)
-        z = np.linalg.solve(L, delta)                   # L z = delta
-        dist2 = np.sum(z * z, axis=0)                   # length-N
-    elif metric == 'z':
-        s = np.std(X, axis=0, ddof=1)
-        s = np.where(s > 0, s, eps)
-        dist2 = np.sum(((X - t) / s) ** 2.0, axis=1)
-    else:  # 'euclidean'
-        dist2 = np.sum((X - t) ** 2.0, axis=1)
-
-    i = int(np.argmin(dist2))
-    return X[i], i, float(dist2[i])
-
-def nearest_sample_to_vector(samples, target, metric='mahalanobis', eps=1e-9):
-    """
-    Return (nearest_sample, index, distance^2) to `target` from `samples`.
-    metrics: 'mahalanobis' | 'z' (z-scored Euclidean) | 'euclidean'
-    """
-    X = np.asarray(samples, dtype=float)
-    t = np.asarray(target,  dtype=float)
-
-    if metric == 'mahalanobis':
-        C = np.cov(X, rowvar=False)
-        # regularize for numerical stability
-        C.flat[::C.shape[0] + 1] += eps
-        L = np.linalg.cholesky(C)
         delta = (X - t).T               # (D, N)
         z = np.linalg.solve(L, delta)   # L z = delta
         dist2 = np.sum(z * z, axis=0)
@@ -329,7 +303,7 @@ def replot(source, representative='median', metric='mahalanobis'):
         color_main = '#FFA833'
     else:  # default: 'median'
         theta_ref = theta_star
-        label_main = r'$\mathrm{MCMC\text{-}nearest\ median}$'
+        label_main = r'$\mathrm{MCMC\text{-}nearest\ Median}$'
         color_main = '#FFA833'
 
     # ---------------- SLED plot (ONLY chosen representative) ----------------
@@ -394,7 +368,7 @@ def replot(source, representative='median', metric='mahalanobis'):
     fig.savefig("./single/{}_corner.pdf".format(source))
     plt.close(fig)
 
-    # Print section below remains unchanged
+    # Print the results
     flatchain_pressure = np.hstack((flatchain[:,[0,1,2]], flatchain[:,[0]]+flatchain[:,[1]]))
     n_c, T_c, N_c, P_c = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]),
                              list(zip(*np.percentile(flatchain_pressure, [16, 50, 84], axis=0))))

--- a/emcee/emcee_radex_2comp.py
+++ b/emcee/emcee_radex_2comp.py
@@ -319,7 +319,7 @@ def replot(source, representative='median', metric='mahalanobis'):
     init_radex(tbg=2.7315 * (1 + z))
     R.set_params(tbg=2.7315 * (1 + z))
 
-    # Build flatchain & within-1σ slice (unchanged)
+    # Build flatchain & within-1σ slice
     flatchain = chain.reshape((-1, 8))
     lnp = lnprobability.reshape((-1, 1))
     lower, upper = np.percentile(flatchain, [16, 84], axis=0)
@@ -345,13 +345,13 @@ def replot(source, representative='median', metric='mahalanobis'):
         theta_ref   = pemcee_max
         theta_ref_c = pemcee_max_c
         theta_ref_w = pemcee_max_w
-        label_main, label_warm, label_cold = r'$\mathrm{MCMC\text{-}Max}$', r'$\mathrm{Max\ warm}$', r'$\mathrm{Max\ cold}$'
+        label_main, label_warm, label_cold = r'$\mathrm{MCMC\text{-}Max}$', r'$\mathrm{Max-warm}$', r'$\mathrm{Max-cold}$'
         color_main, color_warm, color_cold = '#FFA833', '#fcc82d', '#ff7b33'
     else:  # default: 'median'
         theta_ref   = theta_star
         theta_ref_c = theta_star_c
         theta_ref_w = theta_star_w
-        label_main, label_warm, label_cold = r'$\mathrm{MCMC\text{-}nearest\ median}$', r'$\mathrm{Median\ warm}$', r'$\mathrm{Median\ cold}$'
+        label_main, label_warm, label_cold = r'$\mathrm{MCMC\text{-}nearest\ Median}$', r'$\mathrm{Med-warm}$', r'$\mathrm{Med-cold}$'
         color_main, color_warm, color_cold = '#FFA833', '#fcc82d', '#ff7b33'
 
     # ---------------- SLED plot (plot ONLY the chosen representative) ----------------
@@ -453,7 +453,7 @@ def replot(source, representative='median', metric='mahalanobis'):
     fig.savefig(f"./double/{source}_corner_2comp_2.pdf", bbox_inches='tight')
     plt.close(fig)
 
-    # ---------------- Print median ± 1σ (unchanged) ----------------
+    # ---------------- Print median ± 1σ ----------------
     chain_cold_P = np.hstack((chain_cold, chain_cold[:, [0]] + chain_cold[:, [1]]))
     chain_warm_P = np.hstack((chain_warm, chain_warm[:, [0]] + chain_warm[:, [1]]))  # log P = log n + log T
 


### PR DESCRIPTION
Optimize the plotting of the results:
- Now add the lines for plotting the set of parameters coming from a real point in the high-dimensional parameter space that has the values of parameters being closest to the medians.
- Optimize the plotting function to allow users to choose which representative values to plot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replot now lets you choose the representative posterior (median/nearest-to-median or MAP/maximum-likelihood) and the distance metric (Mahalanobis, z-score, or Euclidean).
  * Added utility to pick the nearest posterior sample to a target for more faithful representative plots.
  * Publication-style 3D corner plots for cold and warm components (2-component mode).

* **Refactor**
  * SLED and corner plotting centered on the chosen representative with up to 200 faint posterior overlays, improved z-ordering, legend sizing, and automatic figure cleanup.
  * Percentile-based summary prints updated; replot API updated to accept representative and metric options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->